### PR TITLE
Split up remove tasks for dedicated and shared tenants into their own playbooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,14 @@ include Makefile.*
 generate:
 	ansible-playbook -i inventory/inventory.ini playbooks/as3-config-generate.yaml
 
+apply:
+	ansible-playbook -i inventory/inventory.ini playbooks/as3-config-apply.yaml
+
 apply-in-dev:
 	ansible-playbook -i inventory/inventory.ini playbooks/as3-config-apply.yaml --extra-vars "stage=dev"
 
 clean:
+	ansible-playbook -i inventory/inventory.ini playbooks/as3-config-remove.yaml
 	rm -rf .artifact
 
 run: clean generate apply

--- a/Makefile.test
+++ b/Makefile.test
@@ -18,9 +18,6 @@ test-in-dev:
 	@echo "Send test traffic to dev VS"
 	@curl --fail $(DEV_VS_IP)/headers
 
-apply:
-	ansible-playbook -i inventory/inventory.ini playbooks/as3-config-apply.yaml
-
 VS_STATS_PATH := "/mgmt/tm/ltm/virtual/~as3_openapi~as3_vs_httpbin_proxy_app~as3_vs_httpbin_proxy_svc/stats"
 VS_IP := "192.168.0.201"
 test:

--- a/playbooks/as3-config-apply.yaml
+++ b/playbooks/as3-config-apply.yaml
@@ -10,9 +10,10 @@
       block:
         - name: Get list of tenants to be deployed in dev
           find:
-            paths: "{{ root_dir }}/.artifact/{{ inventory_hostname }}/dev"
+            paths: "{{ root_dir }}/.artifact/{{ inventory_hostname }}"
             file_type: file
-            patterns: "tenant-*"
+            use_regex: true
+            patterns: "tenant-.+_dev\\.json"
           register: files_result
 
         - name: Create dev tenants
@@ -29,7 +30,8 @@
           find:
             paths: "{{ root_dir }}/.artifact/{{ inventory_hostname }}"
             file_type: file
-            patterns: "tenant-*"
+            use_regex: true
+            patterns: "tenant-.+(?<!_dev)\\.json"
           register: files_result
 
         - name: Create tenants

--- a/playbooks/as3-config-generate.yaml
+++ b/playbooks/as3-config-generate.yaml
@@ -17,11 +17,6 @@
             path: "{{ artifact_dir }}"
             state: directory
 
-        - name: Create dev subdir in .artifact directory
-          file:
-            path: "{{ artifact_dir }}/dev"
-            state: directory
-
         - name: Make a note of last run time
           copy:
             content: "last_run: {{ id }}"

--- a/playbooks/as3-config-remove.yaml
+++ b/playbooks/as3-config-remove.yaml
@@ -6,16 +6,18 @@
     - f5networks.f5_bigip
 
   tasks:
-    - name: Remove VS
+    - name: Remove tenants
+      loop: "{{ applications | map(attribute='tenant') | unique | list }}"
+      loop_control:
+        loop_var: tenant_name
       bigip_as3_deploy:
-        content: "{{ lookup('file', '{{ root_dir }}/.artifact/{{ inventory_hostname }}/virtual-server.json') }}"
-
-    - name: Remove dev VS
-      bigip_as3_deploy:
-        content: "{{ lookup('file', '{{ root_dir }}/.artifact/{{ inventory_hostname }}/dev/virtual-server.json') }}"
-
-    - name: Remove firewall policies
-      bigip_as3_deploy:
-        content: "{{ lookup('file', '{{ root_dir }}/.artifact/{{ inventory_hostname }}/firewall-policy.json') }}"
+        tenant: "{{ tenant_name }}"
         state: absent
-        tenant: Common
+
+    - name: Remove dev tenants
+      loop: "{{ applications | selectattr('dev_virtual_address', 'defined') | map(attribute='tenant') | unique | list }}"
+      loop_control:
+        loop_var: tenant_name
+      bigip_as3_deploy:
+        tenant: "{{ tenant_name }}_dev"
+        state: absent

--- a/playbooks/as3-shared-config-remove.yaml
+++ b/playbooks/as3-shared-config-remove.yaml
@@ -1,0 +1,12 @@
+- name: Use Collections
+  hosts: all
+  connection: httpapi
+  gather_facts: false
+  collections:
+    - f5networks.f5_bigip
+
+  tasks:
+    - name: Remove firewall policies
+      bigip_as3_deploy:
+        state: absent
+        tenant: Common

--- a/tasks/generate-tenant-config.yaml
+++ b/tasks/generate-tenant-config.yaml
@@ -2,16 +2,14 @@
   when: deploy_in_dev
   set_fact:
     apps: "{{ applications | selectattr('tenant', 'equalto', tenant) | selectattr('dev_virtual_address', 'defined') | list }}"
-    conf_dir: "{{ artifact_dir }}/dev"
 
 - name: Get apps to be deployed
   when: not deploy_in_dev
   set_fact:
     apps: "{{ applications | selectattr('tenant', 'equalto', tenant) | list }}"
-    conf_dir: "{{ artifact_dir }}"
 
 - name: Generate tenant config{{ " for dev" if deploy_in_dev else ""}}
   when: apps | length != 0
   copy:
     content: "{{ lookup('template', '{{ root_dir }}/templates/tenant.json.j2') | to_json(indent=2) }}"
-    dest: "{{ conf_dir }}/tenant-{{ tenant }}.json"
+    dest: "{{ artifact_dir }}/tenant-{{ tenant }}{{ '_dev' if deploy_in_dev else ''}}.json"


### PR DESCRIPTION
Also:
- fixed bug for removing tenants
- artifact directory is now flat - both dev and prod AS3 JSON files are in the same folder, with `_dev` prefix added in the filename where necessary